### PR TITLE
Implement EtherSpec helper dataclass

### DIFF
--- a/ether/__init__.py
+++ b/ether/__init__.py
@@ -9,5 +9,6 @@ queues, or binary transports.
 
 from .attachment import Attachment
 from .errors import ConversionError, RegistrationError
+from .spec import EtherSpec
 
-__all__ = ["Attachment", "ConversionError", "RegistrationError"]
+__all__ = ["Attachment", "ConversionError", "EtherSpec", "RegistrationError"]

--- a/ether/spec.py
+++ b/ether/spec.py
@@ -1,0 +1,65 @@
+"""EtherSpec helper dataclass for payload/metadata field mapping and validation.
+
+This module provides the EtherSpec dataclass that defines how model fields map
+to Ether envelope payload and metadata sections, including field renames and
+validation rules.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+
+@dataclass
+class EtherSpec:
+    """Defines how model fields map to Ether envelope payload and metadata sections.
+
+    This dataclass specifies which model fields should be mapped to the payload
+    and metadata sections of an Ether envelope, along with field renames and
+    validation rules for extra fields.
+
+    Args:
+        payload_fields: Tuple of field names to map to Ether.payload
+        metadata_fields: Tuple of field names to map to Ether.metadata
+        extra_fields: How to handle unmapped fields ("ignore" | "keep" | "error")
+        renames: Mapping from model field names to Ether dot paths
+        kind: Optional Ether kind identifier
+
+    Raises:
+        RuntimeError: If fields appear in both payload and metadata, or if
+                     renames create duplicate mappings
+    """
+
+    payload_fields: tuple[str, ...]
+    metadata_fields: tuple[str, ...]
+    extra_fields: str = "ignore"  # "ignore" | "keep" | "error"
+    renames: Mapping[str, str] | None = None  # model_field -> ether dot path
+    kind: str | None = None
+
+    def __post_init__(self) -> None:
+        """Validate the EtherSpec configuration after initialization.
+
+        Performs validation checks:
+        - Ensures renames is a dict
+        - Checks for fields that appear in both payload and metadata
+        - Validates that no two fields map to the same Ether path via renames
+
+        Raises:
+            RuntimeError: If validation fails
+        """
+        # Convert renames to dict if None
+        object.__setattr__(self, "renames", dict(self.renames or {}))
+
+        # Check for fields in both payload and metadata
+        dup = set(self.payload_fields) & set(self.metadata_fields)
+        if dup:
+            raise RuntimeError(f"Fields in both payload & metadata: {sorted(dup)}")
+
+        # Check for duplicate mappings in renames
+        used = {}
+        if self.renames:
+            for model_field, path in self.renames.items():
+                if path in used:
+                    raise RuntimeError(f"Duplicate mapping for ether path '{path}'")
+                used[path] = model_field

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -1,0 +1,105 @@
+"""Tests for the EtherSpec dataclass."""
+
+import pytest
+
+from ether.spec import EtherSpec
+
+
+class TestEtherSpec:
+    """Test cases for EtherSpec dataclass."""
+
+    def test_valid_spec_construction(self) -> None:
+        """Test that a valid EtherSpec can be constructed."""
+        spec = EtherSpec(
+            payload_fields=("field1", "field2"),
+            metadata_fields=("meta1",),
+            extra_fields="keep",
+            renames={"field1": "payload.renamed"},
+            kind="test_kind",
+        )
+
+        assert spec.payload_fields == ("field1", "field2")
+        assert spec.metadata_fields == ("meta1",)
+        assert spec.extra_fields == "keep"
+        assert spec.renames == {"field1": "payload.renamed"}
+        assert spec.kind == "test_kind"
+
+    def test_spec_with_defaults(self) -> None:
+        """Test EtherSpec construction with default values."""
+        spec = EtherSpec(payload_fields=("field1",), metadata_fields=("meta1",))
+
+        assert spec.payload_fields == ("field1",)
+        assert spec.metadata_fields == ("meta1",)
+        assert spec.extra_fields == "ignore"
+        assert spec.renames == {}
+        assert spec.kind is None
+
+    def test_spec_with_none_renames(self) -> None:
+        """Test EtherSpec construction with None renames."""
+        spec = EtherSpec(payload_fields=("field1",), metadata_fields=("meta1",), renames=None)
+
+        assert spec.renames == {}
+
+    def test_duplicate_payload_metadata_fields_raises_error(self) -> None:
+        """Test that RuntimeError is raised when fields appear in both payload and metadata."""
+        with pytest.raises(RuntimeError, match="Fields in both payload & metadata: \\['shared_field'\\]"):
+            EtherSpec(payload_fields=("field1", "shared_field"), metadata_fields=("meta1", "shared_field"))
+
+    def test_duplicate_renames_raises_error(self) -> None:
+        """Test that RuntimeError is raised when renames create duplicate mappings."""
+        with pytest.raises(RuntimeError, match="Duplicate mapping for ether path 'payload.duplicate'"):
+            EtherSpec(
+                payload_fields=("field1", "field2"),
+                metadata_fields=("meta1",),
+                renames={"field1": "payload.duplicate", "field2": "payload.duplicate"},
+            )
+
+    def test_spec_is_mutable(self) -> None:
+        """Test that EtherSpec instances are mutable."""
+        spec = EtherSpec(payload_fields=("field1",), metadata_fields=("meta1",))
+
+        # Should be able to modify fields
+        spec.payload_fields = ("new_field",)
+        assert spec.payload_fields == ("new_field",)
+
+    def test_spec_with_empty_fields(self) -> None:
+        """Test EtherSpec with empty field tuples."""
+        spec = EtherSpec(payload_fields=(), metadata_fields=())
+
+        assert spec.payload_fields == ()
+        assert spec.metadata_fields == ()
+        assert spec.renames == {}
+
+    def test_spec_with_complex_renames(self) -> None:
+        """Test EtherSpec with complex nested path renames."""
+        spec = EtherSpec(
+            payload_fields=("embedding", "dim"),
+            metadata_fields=("source",),
+            renames={"embedding": "vec.values", "dim": "vec.dim", "source": "model.source"},
+        )
+
+        assert spec.renames == {"embedding": "vec.values", "dim": "vec.dim", "source": "model.source"}
+
+    def test_spec_equality(self) -> None:
+        """Test that identical EtherSpec instances are equal."""
+        spec1 = EtherSpec(payload_fields=("field1",), metadata_fields=("meta1",), renames={"field1": "payload.field1"})
+
+        spec2 = EtherSpec(payload_fields=("field1",), metadata_fields=("meta1",), renames={"field1": "payload.field1"})
+
+        assert spec1 == spec2
+
+    def test_spec_inequality(self) -> None:
+        """Test that different EtherSpec instances are not equal."""
+        spec1 = EtherSpec(payload_fields=("field1",), metadata_fields=("meta1",))
+
+        spec2 = EtherSpec(payload_fields=("field2",), metadata_fields=("meta1",))
+
+        assert spec1 != spec2
+
+    def test_spec_not_hashable(self) -> None:
+        """Test that EtherSpec instances are not hashable due to dict field."""
+        spec = EtherSpec(payload_fields=("field1",), metadata_fields=("meta1",))
+
+        # Should raise TypeError when trying to hash
+        with pytest.raises(TypeError, match="unhashable type"):
+            hash(spec)


### PR DESCRIPTION
Fixes #24 

- **Added EtherSpec dataclass** in `ether/spec.py` with payload/metadata field mapping
- **Implemented validation logic** that raises RuntimeError on duplicate mappings