### PR TITLE
Stub public package metadata

### DIFF
--- a/ether/__init__.py
+++ b/ether/__init__.py
@@ -5,6 +5,32 @@ data between nodes/layers in composable ML/data systems. It defines the
 intermediate representation (IR) and Python reference implementation for
 the Ether envelope that can be carried over in-memory calls, multiprocess
 queues, or binary transports.
+
+The Ether envelope provides a standardized way to carry structured data
+with metadata and attachments, serving as the intermediate representation
+(IR) for data transport in composable ML/data systems.
+
+Examples:
+    >>> from ether import Ether, Attachment
+    >>>
+    >>> # Create a basic Ether envelope
+    >>> ether = Ether(
+    ...     kind="embedding",
+    ...     schema_version=1,
+    ...     payload={"dim": 768},
+    ...     metadata={"source": "bert-base"}
+    ... )
+    >>>
+    >>> # Create an attachment for large data
+    >>> attachment = Attachment(
+    ...     id="emb-0",
+    ...     uri="shm://embeddings/12345",
+    ...     media_type="application/x-raw-tensor",
+    ...     codec="RAW_F32",
+    ...     shape=[768],
+    ...     dtype="float32"
+    ... )
+    >>> ether.attachments.append(attachment)
 """
 
 from .attachment import Attachment
@@ -12,4 +38,14 @@ from .core import Ether
 from .errors import ConversionError, RegistrationError
 from .spec import EtherSpec
 
-__all__ = ["Attachment", "ConversionError", "Ether", "EtherSpec", "RegistrationError"]
+# Version information
+__version__ = "0.0.0"
+
+# Public API
+__all__ = [
+    "Attachment",
+    "ConversionError",
+    "Ether",
+    "EtherSpec",
+    "RegistrationError",
+]

--- a/ether/attachment.py
+++ b/ether/attachment.py
@@ -3,6 +3,35 @@
 This module defines the Attachment model used in Ether envelopes for handling
 binary data, external buffers, and large tensors/tables that should be transported
 separately from the main payload to enable zero-copy operations.
+
+The Attachment class provides functionality for:
+- External data references via URIs
+- Inline binary data storage
+- Tensor metadata (shape, dtype, device)
+- Compression and checksum support
+- Base64 serialization for JSON transport
+
+Examples:
+    >>> from ether import Attachment
+    >>>
+    >>> # Arrow IPC attachment with external reference
+    >>> att = Attachment(
+    ...     id="table-0",
+    ...     uri="shm://tables/12345",
+    ...     media_type="application/vnd.arrow.ipc",
+    ...     codec="ARROW_IPC",
+    ...     size_bytes=1024
+    ... )
+    >>>
+    >>> # Inline tensor attachment
+    >>> att = Attachment(
+    ...     id="tensor-0",
+    ...     inline_bytes=b"\\x00\\x00\\x80\\x3f",  # 1.0 in float32
+    ...     media_type="application/x-raw-tensor",
+    ...     codec="RAW_F32",
+    ...     shape=[1],
+    ...     dtype="float32"
+    ... )
 """
 
 import base64
@@ -17,6 +46,24 @@ class Attachment(BaseModel):
     Attachments are used for large tensors, tables, or binary data that should be
     transported separately from the main payload to enable zero-copy operations.
     They can reference external data via URIs or contain inline binary data.
+
+    Args:
+        id: Unique identifier for the attachment within the envelope
+        uri: Optional URI reference to external data (e.g., shm://, file://, s3://)
+        inline_bytes: Optional inline binary data (base64 serialized when transported as JSON)
+        media_type: MIME type of the attachment (e.g., application/vnd.arrow.ipc)
+        codec: Optional codec identifier (e.g., ARROW_IPC, DLPACK, RAW_F32)
+        shape: Optional shape dimensions for tensor data
+        dtype: Optional data type (e.g., float32, int8, uint8, bfloat16)
+        byte_order: Optional byte order for numeric data (LE or BE, default: LE)
+        device: Optional device identifier (e.g., cpu, cuda:0, mps)
+        size_bytes: Optional size of the attachment data in bytes
+        compression: Optional compression settings (e.g., {'name': 'zstd', 'level': 3})
+        checksum: Optional checksum information (e.g., {'algo': 'crc32c', 'value': '...'})
+        metadata: Optional attachment-local metadata
+
+    Raises:
+        ValueError: If both uri and inline_bytes are specified, or if neither is specified
 
     Examples:
         >>> # Arrow IPC attachment
@@ -63,7 +110,14 @@ class Attachment(BaseModel):
 
     @field_serializer("inline_bytes")
     def serialize_inline_bytes(self, value: bytes | None) -> str | None:
-        """Serialize inline_bytes as base64 string for JSON serialization."""
+        """Serialize inline_bytes as base64 string for JSON serialization.
+
+        Args:
+            value: The bytes value to serialize
+
+        Returns:
+            Base64 encoded string or None if value is None
+        """
         if value is None:
             return None
         return base64.b64encode(value).decode("ascii")
@@ -71,7 +125,17 @@ class Attachment(BaseModel):
     @field_validator("inline_bytes", mode="before")
     @classmethod
     def validate_inline_bytes(cls, value: Any) -> bytes | None:
-        """Validate and convert inline_bytes from base64 string if needed."""
+        """Validate and convert inline_bytes from base64 string if needed.
+
+        Args:
+            value: The value to validate and convert
+
+        Returns:
+            Bytes value or None
+
+        Raises:
+            ValueError: If value is not bytes or base64 string
+        """
         if value is None:
             return None
         if isinstance(value, bytes):
@@ -84,6 +148,9 @@ class Attachment(BaseModel):
         """Validate attachment configuration after initialization.
 
         Ensures that either uri or inline_bytes is provided, but not both.
+
+        Raises:
+            ValueError: If both uri and inline_bytes are specified, or if neither is specified
         """
         if self.uri is not None and self.inline_bytes is not None:
             raise ValueError("Cannot specify both uri and inline_bytes")

--- a/ether/core.py
+++ b/ether/core.py
@@ -3,6 +3,28 @@
 This module defines the core Ether envelope model that safely transports data
 between nodes/layers in composable ML/data systems. The Ether envelope provides
 a standardized way to carry structured data with metadata and attachments.
+
+The Ether class provides the main envelope functionality with methods for:
+- Registration of Pydantic models for conversion
+- Adapter functions for complex model conversions
+- Conversion between models and Ether envelopes
+- Summary generation for debugging and logging
+
+Examples:
+    >>> from ether import Ether, Attachment
+    >>> from pydantic import BaseModel
+    >>>
+    >>> # Register a model for conversion
+    >>> @Ether.register(payload=["embedding"], metadata=["source"], kind="embedding")
+    ... class EmbeddingModel(BaseModel):
+    ...     embedding: list[float]
+    ...     source: str
+    >>>
+    >>> # Convert model to Ether
+    >>> model = EmbeddingModel(embedding=[1.0, 2.0], source="bert")
+    >>> ether = Ether.from_model(model)
+    >>> ether.kind == "embedding"
+    True
 """
 
 from collections.abc import Callable, Mapping, Sequence

--- a/ether/errors.py
+++ b/ether/errors.py
@@ -2,6 +2,29 @@
 
 This module defines custom exception types used throughout the MaiEther framework
 for handling registration and conversion errors.
+
+The module provides two main exception types:
+- RegistrationError: For model registration issues
+- ConversionError: For Ether conversion issues
+
+Examples:
+    >>> from ether import Ether, RegistrationError, ConversionError
+    >>> from pydantic import BaseModel
+    >>>
+    >>> # RegistrationError example
+    >>> try:
+    ...     @Ether.register(payload=["unknown_field"])
+    ...     class MyModel(BaseModel):
+    ...         valid_field: str
+    ... except RegistrationError as e:
+    ...     print(f"Registration failed: {e}")
+    >>>
+    >>> # ConversionError example
+    >>> ether = Ether(kind="embedding", payload={}, metadata={})
+    >>> try:
+    ...     ether.as_model(SomeModel, require_kind=True)
+    ... except ConversionError as e:
+    ...     print(f"Conversion failed: {e}")
 """
 
 
@@ -11,6 +34,9 @@ class RegistrationError(RuntimeError):
     This exception is raised when attempting to register a model with Ether
     but the registration fails due to invalid configuration, unknown fields,
     or other registration-related issues.
+
+    Args:
+        message: Error message describing the registration failure
 
     Examples:
         >>> @Ether.register(payload=["unknown_field"])
@@ -26,6 +52,9 @@ class ConversionError(RuntimeError):
     This exception is raised when converting between models and Ether envelopes
     fails due to missing required fields, kind mismatches, or other conversion
     issues.
+
+    Args:
+        message: Error message describing the conversion failure
 
     Examples:
         >>> ether = Ether(kind="embedding", payload={}, metadata={})


### PR DESCRIPTION
Fixes #29

Added proper package metadata to ether/__init__.py with __version__ and improved docstrings following Google-style + PyTorch/NumPy conventions.

• Added __version__ placeholder for package versioning • Enhanced module docstring with comprehensive description and usage examples • Improved __all__ list formatting for better readability