### PR TITLE
Add JSON-Schema for `text.v1`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -185,7 +185,7 @@ version = "25.3.0"
 description = "Classes Without Boilerplate"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "attrs-25.3.0-py3-none-any.whl", hash = "sha256:427318ce031701fea540783410126f03899a97ffc6f61596ad581ac2e40e3bc3"},
     {file = "attrs-25.3.0.tar.gz", hash = "sha256:75d7cefc7fb576747b2c81b4442d4d4a1ce0900973527c011d1030fd3bf4af1b"},
@@ -1135,7 +1135,7 @@ version = "4.25.0"
 description = "An implementation of JSON Schema validation for Python"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "jsonschema-4.25.0-py3-none-any.whl", hash = "sha256:24c2e8da302de79c8b9382fee3e76b355e44d2a4364bb207159ce10b517bd716"},
     {file = "jsonschema-4.25.0.tar.gz", hash = "sha256:e63acf5c11762c0e6672ffb61482bdf57f0876684d8d249c0fe2d730d48bc55f"},
@@ -1166,7 +1166,7 @@ version = "2025.4.1"
 description = "The JSON Schema meta-schemas and vocabularies, exposed as a Registry"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "jsonschema_specifications-2025.4.1-py3-none-any.whl", hash = "sha256:4653bffbd6584f7de83a67e0d620ef16900b390ddc7939d56684d6c81e33f1af"},
     {file = "jsonschema_specifications-2025.4.1.tar.gz", hash = "sha256:630159c9f4dbea161a6a2205c3011cc4f18ff381b189fff48bb39b9bf26ae608"},
@@ -2778,7 +2778,7 @@ version = "0.36.2"
 description = "JSON Referencing + Python"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "referencing-0.36.2-py3-none-any.whl", hash = "sha256:e8699adbbf8b5c7de96d8ffa0eb5c158b3beafce084968e2ea8bb08c6794dcd0"},
     {file = "referencing-0.36.2.tar.gz", hash = "sha256:df2e89862cd09deabbdba16944cc3f10feb6b3e6f18e902f7cc25609a34775aa"},
@@ -2897,7 +2897,7 @@ version = "0.26.0"
 description = "Python bindings to Rust's persistent data structures (rpds)"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "rpds_py-0.26.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:4c70c70f9169692b36307a95f3d8c0a9fcd79f7b4a383aad5eaa0e9718b79b37"},
     {file = "rpds_py-0.26.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:777c62479d12395bfb932944e61e915741e364c843afc3196b694db3d669fcd0"},
@@ -3799,4 +3799,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11"
-content-hash = "d0c10f0f44e9c019805155e1c59181ae7a27afcf2f485d509d270503c62aacf0"
+content-hash = "7812ce78437c40a8d6cbff5a37e652726685bf68c95c06b92fc05246a0f5ed3b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ pandas = "^2.3.1"
 # Utilities
 click = "^8.2.1"
 pyyaml = "^6.0.2"
+jsonschema = "^4.25.0"
 
 [tool.poetry.group.dev.dependencies]
 # Testing

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1,0 +1,23 @@
+# MaiEther Schemas
+
+This directory contains JSON Schema definitions for MaiEther data types.
+
+## Available Schemas
+
+### Text
+- [`text/v1.json`](text/v1.json) - Text data transport schema (v1)
+
+## Schema Validation
+
+All schemas in this directory:
+- Use JSON Schema Draft 2020-12
+- Include self-validation against the meta-schema
+- Follow MaiEther envelope structure with `kind`, `schema_version`, `payload`, `metadata`, `extra_fields`, and `attachments`
+
+## Usage
+
+Schemas can be used for:
+- Runtime validation of Ether envelopes
+- Documentation and API specification
+- Cross-language client generation
+- Schema registry integration

--- a/schemas/text/v1.json
+++ b/schemas/text/v1.json
@@ -1,0 +1,145 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://maida.ai/schemas/text/v1.json",
+  "title": "Text v1 Schema",
+  "description": "Schema for text data transport in MaiEther",
+  "type": "object",
+  "required": ["kind", "schema_version", "payload"],
+  "properties": {
+    "kind": {
+      "type": "string",
+      "enum": ["text"],
+      "description": "Logical type identifier for text data"
+    },
+    "schema_version": {
+      "type": "integer",
+      "enum": [1],
+      "description": "Schema version number"
+    },
+    "payload": {
+      "type": "object",
+      "required": ["text"],
+      "properties": {
+        "text": {
+          "type": "string",
+          "description": "The text content"
+        }
+      },
+      "additionalProperties": false
+    },
+    "metadata": {
+      "type": "object",
+      "properties": {
+        "lang": {
+          "type": "string",
+          "description": "Language identifier (optional)"
+        },
+        "encoding": {
+          "type": "string",
+          "description": "Text encoding (optional)"
+        },
+        "detected_lang_conf": {
+          "type": "number",
+          "minimum": 0.0,
+          "maximum": 1.0,
+          "description": "Confidence score for detected language (optional)"
+        }
+      },
+      "additionalProperties": true
+    },
+    "extra_fields": {
+      "type": "object",
+      "description": "Carry-through for unclassified fields"
+    },
+    "attachments": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "media_type"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for the attachment"
+          },
+          "uri": {
+            "type": "string",
+            "description": "URI to the attachment data"
+          },
+          "inline_bytes": {
+            "type": "string",
+            "description": "Base64 encoded inline data"
+          },
+          "media_type": {
+            "type": "string",
+            "description": "MIME type of the attachment"
+          },
+          "codec": {
+            "type": "string",
+            "description": "Codec identifier"
+          },
+          "shape": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            },
+            "description": "Shape of tensor data"
+          },
+          "dtype": {
+            "type": "string",
+            "description": "Data type identifier"
+          },
+          "byte_order": {
+            "type": "string",
+            "enum": ["LE", "BE"],
+            "default": "LE",
+            "description": "Byte order for binary data"
+          },
+          "device": {
+            "type": "string",
+            "description": "Device identifier (e.g., cpu, cuda:0)"
+          },
+          "size_bytes": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Size in bytes"
+          },
+          "compression": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "enum": ["zstd", "lz4", "none"]
+              },
+              "level": {
+                "type": "integer",
+                "minimum": 0
+              }
+            },
+            "required": ["name"]
+          },
+          "checksum": {
+            "type": "object",
+            "properties": {
+              "algo": {
+                "type": "string",
+                "enum": ["crc32c", "sha256"]
+              },
+              "value": {
+                "type": "string",
+                "pattern": "^[0-9a-fA-F]+$"
+              }
+            },
+            "required": ["algo", "value"]
+          },
+          "metadata": {
+            "type": "object",
+            "description": "Attachment-local metadata"
+          }
+        },
+        "additionalProperties": false
+      },
+      "description": "List of binary or external buffers"
+    }
+  },
+  "additionalProperties": false
+}

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1,0 +1,166 @@
+"""Tests for JSON Schema validation."""
+
+import json
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+
+class TestTextV1Schema:
+    """Test the text.v1 JSON schema."""
+
+    def setup_method(self) -> None:
+        """Load the text.v1 schema."""
+        schema_path = Path(__file__).parent.parent / "schemas" / "text" / "v1.json"
+        with open(schema_path) as f:
+            self.schema = json.load(f)
+        self.validator = Draft202012Validator(self.schema)
+
+    def test_schema_validates_against_draft_2020_12(self) -> None:
+        """Test that the schema itself validates against JSON-Schema draft 2020-12."""
+        # Create a validator for the meta-schema
+        meta_validator = Draft202012Validator(Draft202012Validator.META_SCHEMA)
+
+        # Validate our schema against the meta-schema
+        errors = list(meta_validator.iter_errors(self.schema))
+        assert not errors, f"Schema validation errors: {errors}"
+
+    def test_valid_text_v1_document(self) -> None:
+        """Test that a valid text.v1 document passes validation."""
+        valid_doc = {
+            "kind": "text",
+            "schema_version": 1,
+            "payload": {"text": "Hello, world!"},
+            "metadata": {"lang": "en"},
+            "extra_fields": {},
+            "attachments": [],
+        }
+
+        errors = list(self.validator.iter_errors(valid_doc))
+        assert not errors, f"Validation errors: {errors}"
+
+    def test_required_keys_present(self) -> None:
+        """Test that required keys are enforced."""
+        # Test missing kind
+        doc_without_kind = {"schema_version": 1, "payload": {"text": "Hello"}}
+        errors = list(self.validator.iter_errors(doc_without_kind))
+        assert any("kind" in str(error) for error in errors)
+
+        # Test missing schema_version
+        doc_without_version = {"kind": "text", "payload": {"text": "Hello"}}
+        errors = list(self.validator.iter_errors(doc_without_version))
+        assert any("schema_version" in str(error) for error in errors)
+
+        # Test missing payload
+        doc_without_payload = {"kind": "text", "schema_version": 1}
+        errors = list(self.validator.iter_errors(doc_without_payload))
+        assert any("payload" in str(error) for error in errors)
+
+        # Test missing payload.text
+        doc_without_text = {"kind": "text", "schema_version": 1, "payload": {}}
+        errors = list(self.validator.iter_errors(doc_without_text))
+        assert any("text" in str(error) for error in errors)
+
+    def test_kind_must_be_text(self) -> None:
+        """Test that kind must be 'text'."""
+        doc_with_wrong_kind = {"kind": "embedding", "schema_version": 1, "payload": {"text": "Hello"}}
+        errors = list(self.validator.iter_errors(doc_with_wrong_kind))
+        assert any("kind" in str(error) for error in errors)
+
+    def test_schema_version_must_be_1(self) -> None:
+        """Test that schema_version must be 1."""
+        doc_with_wrong_version = {"kind": "text", "schema_version": 2, "payload": {"text": "Hello"}}
+        errors = list(self.validator.iter_errors(doc_with_wrong_version))
+        assert any("schema_version" in str(error) for error in errors)
+
+    def test_payload_text_must_be_string(self) -> None:
+        """Test that payload.text must be a string."""
+        doc_with_non_string_text = {"kind": "text", "schema_version": 1, "payload": {"text": 123}}
+        errors = list(self.validator.iter_errors(doc_with_non_string_text))
+        assert any("text" in str(error) for error in errors)
+
+    def test_optional_metadata_lang(self) -> None:
+        """Test that metadata.lang is optional and must be string."""
+        # Test with valid lang
+        doc_with_lang = {"kind": "text", "schema_version": 1, "payload": {"text": "Hello"}, "metadata": {"lang": "en"}}
+        errors = list(self.validator.iter_errors(doc_with_lang))
+        assert not errors
+
+        # Test with non-string lang
+        doc_with_invalid_lang = {
+            "kind": "text",
+            "schema_version": 1,
+            "payload": {"text": "Hello"},
+            "metadata": {"lang": 123},
+        }
+        errors = list(self.validator.iter_errors(doc_with_invalid_lang))
+        assert any("lang" in str(error) for error in errors)
+
+    def test_metadata_encoding_optional(self) -> None:
+        """Test that metadata.encoding is optional."""
+        doc_with_encoding = {
+            "kind": "text",
+            "schema_version": 1,
+            "payload": {"text": "Hello"},
+            "metadata": {"encoding": "utf-8"},
+        }
+        errors = list(self.validator.iter_errors(doc_with_encoding))
+        assert not errors
+
+    def test_metadata_detected_lang_conf_range(self) -> None:
+        """Test that metadata.detected_lang_conf must be between 0.0 and 1.0."""
+        # Test valid confidence
+        doc_with_valid_conf = {
+            "kind": "text",
+            "schema_version": 1,
+            "payload": {"text": "Hello"},
+            "metadata": {"detected_lang_conf": 0.8},
+        }
+        errors = list(self.validator.iter_errors(doc_with_valid_conf))
+        assert not errors
+
+        # Test invalid confidence (too high)
+        doc_with_high_conf = {
+            "kind": "text",
+            "schema_version": 1,
+            "payload": {"text": "Hello"},
+            "metadata": {"detected_lang_conf": 1.5},
+        }
+        errors = list(self.validator.iter_errors(doc_with_high_conf))
+        assert any("detected_lang_conf" in str(error) for error in errors)
+
+        # Test invalid confidence (negative)
+        doc_with_negative_conf = {
+            "kind": "text",
+            "schema_version": 1,
+            "payload": {"text": "Hello"},
+            "metadata": {"detected_lang_conf": -0.1},
+        }
+        errors = list(self.validator.iter_errors(doc_with_negative_conf))
+        assert any("detected_lang_conf" in str(error) for error in errors)
+
+    def test_attachments_structure(self) -> None:
+        """Test that attachments have the correct structure."""
+        doc_with_attachments = {
+            "kind": "text",
+            "schema_version": 1,
+            "payload": {"text": "Hello"},
+            "attachments": [{"id": "att-1", "media_type": "application/octet-stream", "size_bytes": 1024}],
+        }
+        errors = list(self.validator.iter_errors(doc_with_attachments))
+        assert not errors
+
+        # Test missing required attachment fields
+        doc_with_invalid_attachment = {
+            "kind": "text",
+            "schema_version": 1,
+            "payload": {"text": "Hello"},
+            "attachments": [
+                {
+                    "id": "att-1"
+                    # Missing media_type
+                }
+            ],
+        }
+        errors = list(self.validator.iter_errors(doc_with_invalid_attachment))
+        assert any("media_type" in str(error) for error in errors)


### PR DESCRIPTION
Fixes #39

Added JSON Schema definition for text.v1 data type with comprehensive validation.

• Created `schemas/text/v1.json` with JSON Schema Draft 2020-12 validation • Added `schemas/README.md` index for schema documentation • Added `jsonschema` dependency for schema validation • Created comprehensive test suite for schema validation