### PR TITLE
# Add JSON-Schema for `embedding.v1`

### DIFF
--- a/.cursor/rules/resolve-issue.mdc
+++ b/.cursor/rules/resolve-issue.mdc
@@ -2,6 +2,8 @@
 alwaysApply: false
 ---
 
+*If this rule invoked in chat, name the chat thread "Issue #XX Resolution"*
+
 **Task Rules**
 - Create a code change / PR to resolve an issue
 - The issue will be given to you either as a filename or `#XX` format
@@ -15,13 +17,14 @@ alwaysApply: false
 - Once the code is written you must make sure it passes tests if applicable, as well as coverage
 - One all the tests are done, create a file `.issues/commit-msg-XX.md` with a brief commit message with a bulletlist of changes that were introduced.
   - `XX` is the same as in the issue file name.
-  - Commit message must have the following structure (split by blank lines):
+  - Commit message must have the following structure (split by blank lines) in GitHub markdown format:
     - Start with the title (usually the same as in the issue description)
     - "Fixes #XX", where `XX` is the issue number
     - A brief description with motivation (ONLY if applicable)
     - Bullet list of changes
   - The bulletlist should be very high level, and not longer than 3-4 items. It should exclude common-sense changes such as "Added tests" (this is required anyway), "Added to `__init__.py`" (this is often required), etc.
     - Bulletlist should only include functional changes
+    - Every bulletpoint must start with "-"
     - Exceptions: Sometimes the issue is about tests or lint or imports, or other obvious things. In that case we should make sure we add it to change list
 
 **Tools**

--- a/schemas/embedding/v1.json
+++ b/schemas/embedding/v1.json
@@ -1,0 +1,136 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://maida.ai/schemas/embedding/v1.json",
+  "title": "Embedding v1 Schema",
+  "description": "Schema for embedding data transport in MaiEther",
+  "type": "object",
+  "required": ["kind", "schema_version", "payload"],
+  "properties": {
+    "kind": {
+      "type": "string",
+      "enum": ["embedding"],
+      "description": "Logical type identifier for embedding data"
+    },
+    "schema_version": {
+      "type": "integer",
+      "enum": [1],
+      "description": "Schema version number"
+    },
+    "payload": {
+      "type": "object",
+      "required": ["dim"],
+      "properties": {
+        "dim": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Dimensionality of the embedding vectors"
+        }
+      },
+      "additionalProperties": false
+    },
+    "metadata": {
+      "type": "object",
+      "properties": {
+        "source": {
+          "type": "string",
+          "description": "Source identifier for the embedding model"
+        }
+      },
+      "additionalProperties": true
+    },
+    "extra_fields": {
+      "type": "object",
+      "description": "Carry-through for unclassified fields"
+    },
+    "attachments": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "media_type"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for the attachment"
+          },
+          "uri": {
+            "type": "string",
+            "description": "URI to the attachment data"
+          },
+          "inline_bytes": {
+            "type": "string",
+            "description": "Base64 encoded inline data"
+          },
+          "media_type": {
+            "type": "string",
+            "description": "MIME type of the attachment"
+          },
+          "codec": {
+            "type": "string",
+            "description": "Codec identifier"
+          },
+          "shape": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            },
+            "description": "Shape of tensor data"
+          },
+          "dtype": {
+            "type": "string",
+            "description": "Data type identifier"
+          },
+          "byte_order": {
+            "type": "string",
+            "enum": ["LE", "BE"],
+            "default": "LE",
+            "description": "Byte order for binary data"
+          },
+          "device": {
+            "type": "string",
+            "description": "Device identifier (e.g., cpu, cuda:0)"
+          },
+          "size_bytes": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Size in bytes"
+          },
+          "compression": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "enum": ["zstd", "lz4", "none"]
+              },
+              "level": {
+                "type": "integer",
+                "minimum": 0
+              }
+            },
+            "required": ["name"]
+          },
+          "checksum": {
+            "type": "object",
+            "properties": {
+              "algo": {
+                "type": "string",
+                "enum": ["crc32c", "sha256"]
+              },
+              "value": {
+                "type": "string",
+                "pattern": "^[0-9a-fA-F]+$"
+              }
+            },
+            "required": ["algo", "value"]
+          },
+          "metadata": {
+            "type": "object",
+            "description": "Attachment-local metadata"
+          }
+        },
+        "additionalProperties": false
+      },
+      "description": "List of binary or external buffers"
+    }
+  },
+  "additionalProperties": false
+}

--- a/tests/kinds/embedding/__init__.py
+++ b/tests/kinds/embedding/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for embedding model kind."""

--- a/tests/kinds/embedding/test_schema.py
+++ b/tests/kinds/embedding/test_schema.py
@@ -1,0 +1,171 @@
+"""Tests for JSON Schema validation."""
+
+import json
+
+from jsonschema import Draft202012Validator
+
+from tests.kinds import SCHEMAS_DIR
+
+
+class TestEmbeddingV1Schema:
+    """Test the embedding.v1 JSON schema."""
+
+    def setup_method(self) -> None:
+        """Load the embedding.v1 schema."""
+        schema_path = SCHEMAS_DIR / "embedding" / "v1.json"
+        with open(schema_path) as f:
+            self.schema = json.load(f)
+        self.validator = Draft202012Validator(self.schema)
+
+    def test_schema_validates_against_draft_2020_12(self) -> None:
+        """Test that the schema itself validates against JSON-Schema draft 2020-12."""
+        # Create a validator for the meta-schema
+        meta_validator = Draft202012Validator(Draft202012Validator.META_SCHEMA)
+
+        # Validate our schema against the meta-schema
+        errors = list(meta_validator.iter_errors(self.schema))
+        assert not errors, f"Schema validation errors: {errors}"
+
+    def test_valid_embedding_v1_document(self) -> None:
+        """Test that a valid embedding.v1 document passes validation."""
+        valid_doc = {
+            "kind": "embedding",
+            "schema_version": 1,
+            "payload": {"dim": 768},
+            "metadata": {"source": "bert-base-uncased"},
+            "extra_fields": {},
+            "attachments": [],
+        }
+
+        errors = list(self.validator.iter_errors(valid_doc))
+        assert not errors, f"Validation errors: {errors}"
+
+    def test_required_keys_present(self) -> None:
+        """Test that required keys are enforced."""
+        # Test missing kind
+        doc_without_kind = {"schema_version": 1, "payload": {"dim": 768}}
+        errors = list(self.validator.iter_errors(doc_without_kind))
+        assert any("kind" in str(error) for error in errors)
+
+        # Test missing schema_version
+        doc_without_version = {"kind": "embedding", "payload": {"dim": 768}}
+        errors = list(self.validator.iter_errors(doc_without_version))
+        assert any("schema_version" in str(error) for error in errors)
+
+        # Test missing payload
+        doc_without_payload = {"kind": "embedding", "schema_version": 1}
+        errors = list(self.validator.iter_errors(doc_without_payload))
+        assert any("payload" in str(error) for error in errors)
+
+        # Test missing payload.dim
+        doc_without_dim = {"kind": "embedding", "schema_version": 1, "payload": {}}
+        errors = list(self.validator.iter_errors(doc_without_dim))
+        assert any("dim" in str(error) for error in errors)
+
+    def test_kind_must_be_embedding(self) -> None:
+        """Test that kind must be 'embedding'."""
+        doc_with_wrong_kind = {"kind": "text", "schema_version": 1, "payload": {"dim": 768}}
+        errors = list(self.validator.iter_errors(doc_with_wrong_kind))
+        assert any("kind" in str(error) for error in errors)
+
+    def test_schema_version_must_be_1(self) -> None:
+        """Test that schema_version must be 1."""
+        doc_with_wrong_version = {"kind": "embedding", "schema_version": 2, "payload": {"dim": 768}}
+        errors = list(self.validator.iter_errors(doc_with_wrong_version))
+        assert any("schema_version" in str(error) for error in errors)
+
+    def test_payload_dim_must_be_integer(self) -> None:
+        """Test that payload.dim must be an integer."""
+        doc_with_non_integer_dim = {"kind": "embedding", "schema_version": 1, "payload": {"dim": "768"}}
+        errors = list(self.validator.iter_errors(doc_with_non_integer_dim))
+        assert any("dim" in str(error) for error in errors)
+
+    def test_payload_dim_must_be_positive(self) -> None:
+        """Test that payload.dim must be at least 1."""
+        # Test with zero
+        doc_with_zero_dim = {"kind": "embedding", "schema_version": 1, "payload": {"dim": 0}}
+        errors = list(self.validator.iter_errors(doc_with_zero_dim))
+        assert any("dim" in str(error) for error in errors)
+
+        # Test with negative
+        doc_with_negative_dim = {"kind": "embedding", "schema_version": 1, "payload": {"dim": -1}}
+        errors = list(self.validator.iter_errors(doc_with_negative_dim))
+        assert any("dim" in str(error) for error in errors)
+
+    def test_optional_metadata_source(self) -> None:
+        """Test that metadata.source is optional and must be string."""
+        # Test with valid source
+        doc_with_source = {
+            "kind": "embedding",
+            "schema_version": 1,
+            "payload": {"dim": 768},
+            "metadata": {"source": "bert-base-uncased"},
+        }
+        errors = list(self.validator.iter_errors(doc_with_source))
+        assert not errors
+
+        # Test with non-string source
+        doc_with_invalid_source = {
+            "kind": "embedding",
+            "schema_version": 1,
+            "payload": {"dim": 768},
+            "metadata": {"source": 123},
+        }
+        errors = list(self.validator.iter_errors(doc_with_invalid_source))
+        assert any("source" in str(error) for error in errors)
+
+        # Test without source (should be valid)
+        doc_without_source = {
+            "kind": "embedding",
+            "schema_version": 1,
+            "payload": {"dim": 768},
+            "metadata": {},
+        }
+        errors = list(self.validator.iter_errors(doc_without_source))
+        assert not errors
+
+    def test_attachments_structure(self) -> None:
+        """Test that attachments have the correct structure."""
+        doc_with_attachments = {
+            "kind": "embedding",
+            "schema_version": 1,
+            "payload": {"dim": 768},
+            "attachments": [{"id": "att-1", "media_type": "application/octet-stream", "size_bytes": 1024}],
+        }
+        errors = list(self.validator.iter_errors(doc_with_attachments))
+        assert not errors
+
+        # Test missing required attachment fields
+        doc_with_invalid_attachment = {
+            "kind": "embedding",
+            "schema_version": 1,
+            "payload": {"dim": 768},
+            "attachments": [
+                {
+                    "id": "att-1"
+                    # Missing media_type
+                }
+            ],
+        }
+        errors = list(self.validator.iter_errors(doc_with_invalid_attachment))
+        assert any("media_type" in str(error) for error in errors)
+
+    def test_extra_fields_optional(self) -> None:
+        """Test that extra_fields is optional."""
+        doc_with_extra_fields = {
+            "kind": "embedding",
+            "schema_version": 1,
+            "payload": {"dim": 768},
+            "extra_fields": {"custom_field": "value"},
+        }
+        errors = list(self.validator.iter_errors(doc_with_extra_fields))
+        assert not errors
+
+        # Test without extra_fields (should be valid)
+        doc_without_extra_fields = {
+            "kind": "embedding",
+            "schema_version": 1,
+            "payload": {"dim": 768},
+        }
+        errors = list(self.validator.iter_errors(doc_without_extra_fields))
+        assert not errors


### PR DESCRIPTION
Fixes #43

- Created `schemas/embedding/v1.json` with required `payload.dim` field and optional `metadata.source` field
- Included standard attachment descriptor structure for future compatibility